### PR TITLE
Prettier Import Sorting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-npm run format:check && npm run lint && npm run typecheck
+npm run format-staged
+npm run lint
+npm run typecheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "always"
-  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
+        "prettier-plugin-organize-imports": "^4.3.0",
+        "pretty-quick": "^4.2.2",
         "sass": "^1.89.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.63.0",
@@ -1311,6 +1313,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.10.tgz",
+      "integrity": "sha512-x6fFWCeak8aCGfqZfe6CXYt5xVjxe9Os1cIPmVRcToInKLjhJkRVXvJ/L3/1KxFkjDQdbZV/YsuLKqa8t/xKpA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4327,6 +4342,16 @@
         "node": "*"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4689,6 +4714,61 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz",
+      "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pretty-quick": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.2.2.tgz",
+      "integrity": "sha512-uAh96tBW1SsD34VhhDmWuEmqbpfYc/B3j++5MC/6b3Cb8Ow7NJsvKFhg0eoGu2xXX+o9RkahkTK6sUdd8E7g5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.7",
+        "ignore": "^7.0.5",
+        "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "tinyexec": "^0.3.2",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "pretty-quick": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pretty-quick"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/prop-types": {
@@ -5309,6 +5389,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5356,6 +5443,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",
+    "prettier-plugin-organize-imports": "^4.3.0",
+    "pretty-quick": "^4.2.2",
     "sass": "^1.89.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0",
@@ -36,6 +38,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format-staged": "pretty-quick --staged",
     "typecheck": "tsc --noEmit",
     "prepare": "husky"
   },

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import("prettier").Config} */
 export default {
+  // Uses TypeScript's organize imports (same as VS Code source.organizeImports)
+  plugins: ['prettier-plugin-organize-imports'],
+
   // Line formatting
   printWidth: 120,
   tabWidth: 2,

--- a/src/lib/webgl/canvasShader.ts
+++ b/src/lib/webgl/canvasShader.ts
@@ -9,7 +9,6 @@ export default class CanvasShader extends Shader {
   draw({ gl, renderingPass, colorTextures }: CanvasVars) {
     if (this.pgm && gl && colorTextures) {
       gl.bindFramebuffer(gl.FRAMEBUFFER, null)
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       gl.useProgram(this.pgm)
       gl.bindVertexArray(this.vao)
       colorTextures.bindToCanvasShader(gl, this.pgm)

--- a/src/lib/webgl/sampleShader.ts
+++ b/src/lib/webgl/sampleShader.ts
@@ -37,7 +37,6 @@ export default class SampleShader extends Shader {
       const eyePos = origin.mul(scene.cameraNode.modelMatrix) // in world space
 
       gl.bindFramebuffer(gl.FRAMEBUFFER, this.frameBuffer)
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       gl.useProgram(this.pgm)
       gl.bindVertexArray(this.vao)
 


### PR DESCRIPTION
Use prettier to sort imports in a precommit hook as well as every time prettier runs so that all source files are modified to the same standard regardless of how the source files are edited.
